### PR TITLE
modify $PATH instead of definibg aliases

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -44,7 +44,9 @@ goenv_setup() {
   ln -sf ${GOROOT}/bin/go $GOBIN/go
   ln -sf ${GOROOT}/bin/gofmt $GOBIN/gofmt
   ln -sf ${GOROOT}/bin/godoc $GOBIN/godoc
-  export PATH="$GOBIN:$PATH"
+  CUR_PATH=$PATH
+  export PATH=$GOBIN
+  for p in ${CUR_PATH//:/ }; do [[ ! "$p" =~ 'goenv' ]] && export PATH="$PATH:$p"; done;
 }
 
 goclean() {


### PR DESCRIPTION
After `goon` command the $PATH will looks like this

```
$ echo $GOPATH
/Users/aeg/.goenv/gosample:/Users/aeg/Devel/gosample
$ echo $PATH
/Users/aeg/.goenv/gosample/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

And it will be transparent to use `go` tool

```
$ which go
/Users/aeg/.goenv/gosample/bin/go
```

And this meets the reccomendations about [The GOPATH environment variable](http://golang.org/doc/code.html)
