### PR TITLE
expand $PATH instead of symlinking go binaries

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -41,11 +41,8 @@ goenv_setup() {
   export GOBIN="${GOENV_PATH}/bin"
   export GOPATH="${GOENV_PATH}:$(pwd)"
 
-  ln -sf ${GOROOT}/bin/go $GOBIN/go
-  ln -sf ${GOROOT}/bin/gofmt $GOBIN/gofmt
-  ln -sf ${GOROOT}/bin/godoc $GOBIN/godoc
   CUR_PATH=$PATH
-  export PATH=$GOBIN
+  export PATH="${GOROOT}/bin:$GOBIN"
   for p in ${CUR_PATH//:/ }; do [[ ! "$p" =~ 'goenv' ]] && export PATH="$PATH:$p"; done;
 }
 

--- a/activate.sh
+++ b/activate.sh
@@ -82,7 +82,7 @@ gom() {
     return
   fi
   if [ ! -f $GOBIN/gom ]; then
-    $GOBIN/go get github.com/mattn/gom
+    go get github.com/mattn/gom
     rm -rf vendor
     ln -sf $GOENV_PATH vendor
   fi


### PR DESCRIPTION
Is any good reason to make symlinks for go binaries? I suggest to modify $PATH variable instead.
